### PR TITLE
Add more standard rules and eliminate Seq views

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -125,6 +125,7 @@ lazy val root = project.in(file(".")).
         "-Ywarn-dead-code",
         "-Ywarn-value-discard",
         "-Xmax-classfile-name", "128",
-        "-Xfatal-warnings"
+        "-Xfatal-warnings",
+        "-Ypartial-unification"
       )
     )

--- a/build.sbt
+++ b/build.sbt
@@ -124,8 +124,8 @@ lazy val root = project.in(file(".")).
         "-Yno-adapted-args",
         "-Ywarn-dead-code",
         "-Ywarn-value-discard",
+        "-Ypartial-unification",
         "-Xmax-classfile-name", "128",
-        "-Xfatal-warnings",
-        "-Ypartial-unification"
+        "-Xfatal-warnings"
       )
     )

--- a/checklist/src/main/scala/checklist/Indexable.scala
+++ b/checklist/src/main/scala/checklist/Indexable.scala
@@ -1,30 +1,47 @@
 package checklist
 
-import scala.language.higherKinds
 
 trait Indexable[S[_]] {
-  def zipWithIndex[A](values: S[A]): S[(A, Int)]
+  def mapWithIndex[A, B](values: S[A])(f: (A, Int) => B): S[B]
+  def zipWithIndex[A](values: S[A]): S[(A, Int)] = mapWithIndex(values)((a, i) => (a, i))
 }
 
-object Indexable {
+object Indexable extends LowPriorityIndexable {
   def apply[S[_]](implicit indexable: Indexable[S]): Indexable[S] =
     indexable
 
   implicit val listIndexable: Indexable[List] =
     new Indexable[List] {
-      def zipWithIndex[A](values: List[A]): List[(A, Int)] =
+      def mapWithIndex[A, B](values: List[A])(f: (A, Int) => B) = values.zipWithIndex.map { case (a, i) => f(a, i) }
+      override def zipWithIndex[A](values: List[A]): List[(A, Int)] =
         values.zipWithIndex
     }
 
   implicit val vectorIndexable: Indexable[Vector] =
     new Indexable[Vector] {
-      def zipWithIndex[A](values: Vector[A]): Vector[(A, Int)] =
+      def mapWithIndex[A, B](values: Vector[A])(f: (A, Int) => B) = values.zipWithIndex.map { case (a, i) => f(a, i) }
+      override def zipWithIndex[A](values: Vector[A]): Vector[(A, Int)] =
         values.zipWithIndex
     }
 
   implicit val streamIndexable: Indexable[Stream] =
     new Indexable[Stream] {
-      def zipWithIndex[A](values: Stream[A]): Stream[(A, Int)] =
+      def mapWithIndex[A, B](values: Stream[A])(f: (A, Int) => B) = values.zipWithIndex.map { case (a, i) => f(a, i) }
+      override def zipWithIndex[A](values: Stream[A]): Stream[(A, Int)] =
         values.zipWithIndex
     }
+}
+
+trait LowPriorityIndexable {
+  import cats.Traverse
+  // Most of the stuff below is stolen from cats 1.0.0-MF's Traverse. Once this lib is on cats 1.0.0, Indexable can disappear because traverse does all of this.
+  implicit def indexableFromTraverse[S[_]: Traverse]: Indexable[S] = {
+    new Indexable[S] {
+      import cats.data.State
+      import cats.implicits._
+      def mapWithIndex[A, B](values: S[A])(f: (A, Int) => B): S[B] =
+        values.traverse(a => State((s: Int) => (s + 1, f(a, s)))).runA(0).value
+    }
+  }
+
 }

--- a/checklist/src/main/scala/checklist/Indexable.scala
+++ b/checklist/src/main/scala/checklist/Indexable.scala
@@ -6,9 +6,12 @@ trait Indexable[S[_]] {
   def zipWithIndex[A](values: S[A]): S[(A, Int)] = mapWithIndex(values)((a, i) => (a, i))
 }
 
-object Indexable extends LowPriorityIndexable {
+object Indexable extends IndexableInstances {
   def apply[S[_]](implicit indexable: Indexable[S]): Indexable[S] =
     indexable
+}
+
+trait IndexableInstances extends LowPriorityIndexableInstances {
 
   implicit val listIndexable: Indexable[List] =
     new Indexable[List] {
@@ -30,9 +33,10 @@ object Indexable extends LowPriorityIndexable {
       override def zipWithIndex[A](values: Stream[A]): Stream[(A, Int)] =
         values.zipWithIndex
     }
+
 }
 
-trait LowPriorityIndexable {
+trait LowPriorityIndexableInstances {
   import cats.Traverse
   // Most of the stuff below is stolen from cats 1.0.0-MF's Traverse. Once this lib is on cats 1.0.0, Indexable can disappear because traverse does all of this.
   implicit def indexableFromTraverse[S[_]: Traverse]: Indexable[S] = {

--- a/checklist/src/main/scala/checklist/Indexable.scala
+++ b/checklist/src/main/scala/checklist/Indexable.scala
@@ -6,7 +6,7 @@ trait Indexable[S[_]] {
   def zipWithIndex[A](values: S[A]): S[(A, Int)] = mapWithIndex(values)((a, i) => (a, i))
 }
 
-object Indexable extends IndexableInstances {
+object Indexable extends IndexableInstances with IndexableSyntax {
   def apply[S[_]](implicit indexable: Indexable[S]): Indexable[S] =
     indexable
 }

--- a/checklist/src/main/scala/checklist/IndexableSyntax.scala
+++ b/checklist/src/main/scala/checklist/IndexableSyntax.scala
@@ -1,0 +1,16 @@
+package checklist
+
+import cats.implicits._
+import cats.{Applicative, Traverse}
+
+object IndexableSyntax extends IndexableSyntax
+
+trait IndexableSyntax {
+  implicit class IndexableOps[S[_], A](sa: S[A])(implicit indexable: Indexable[S]) {
+    def zipWithIndex: S[(A, Int)] = indexable.zipWithIndex(sa)
+    def mapWithIndex[B](f: (A, Int) => B): S[B] = indexable.mapWithIndex(sa)(f)
+
+    def traverseWithIndex[F[_]: Applicative, B](f: (A, Int) => F[B])(implicit traverse: Traverse[S]): F[S[B]] =
+      indexable.mapWithIndex(sa)(f).sequence
+  }
+}

--- a/checklist/src/main/scala/checklist/IndexableSyntax.scala
+++ b/checklist/src/main/scala/checklist/IndexableSyntax.scala
@@ -6,11 +6,11 @@ import cats.{Applicative, Traverse}
 object IndexableSyntax extends IndexableSyntax
 
 trait IndexableSyntax {
-  implicit class IndexableOps[S[_], A](sa: S[A])(implicit indexable: Indexable[S]) {
-    def zipWithIndex: S[(A, Int)] = indexable.zipWithIndex(sa)
-    def mapWithIndex[B](f: (A, Int) => B): S[B] = indexable.mapWithIndex(sa)(f)
+  implicit class IndexableOps2[S[_], A](sa: S[A]) {
+    def zipWithIndex(implicit indexable: Indexable[S]): S[(A, Int)] = indexable.zipWithIndex(sa)
+    def mapWithIndex[B](f: (A, Int) => B)(implicit indexable: Indexable[S]): S[B] = indexable.mapWithIndex(sa)(f)
 
-    def traverseWithIndex[F[_]: Applicative, B](f: (A, Int) => F[B])(implicit traverse: Traverse[S]): F[S[B]] =
+    def traverseWithIndex[F[_]: Applicative, B](f: (A, Int) => F[B])(implicit traverse: Traverse[S], indexable: Indexable[S]): F[S[B]] =
       indexable.mapWithIndex(sa)(f).sequence
   }
 }

--- a/checklist/src/main/scala/checklist/Rule.scala
+++ b/checklist/src/main/scala/checklist/Rule.scala
@@ -8,6 +8,7 @@ import scala.language.higherKinds
 import scala.util.matching.Regex
 import Message.errors
 import cats.data.NonEmptyList
+import checklist.IndexableSyntax._
 
 sealed abstract class Rule[A, B] {
   def apply(value: A): Checked[B]
@@ -63,7 +64,7 @@ sealed abstract class Rule[A, B] {
       }
     }
 
-  def seq[S[_]: Indexable: Traverse]: Rule[S[A], S[B]] =
+  def seq[S[_]: Traverse]: Rule[S[A], S[B]] =
     Rule.sequence(this)
 
   def opt: Rule[Option[A], Option[B]] =
@@ -347,10 +348,9 @@ trait CollectionRules {
       case None        => Ior.left(messages)
     }
 
-  def sequence[S[_] : Indexable : Traverse, A, B](rule: Rule[A, B]): Rule[S[A], S[B]] =
+  def sequence[S[_] : Traverse : Indexable, A, B](rule: Rule[A, B]): Rule[S[A], S[B]] =
     pure { values =>
-      Indexable[S].zipWithIndex(values).traverse {
-        case (value, index) =>
+      values.traverseWithIndex { (value, index) =>
           rule.prefix(index).apply(value)
       }
     }

--- a/checklist/src/main/scala/checklist/Rule.scala
+++ b/checklist/src/main/scala/checklist/Rule.scala
@@ -248,10 +248,10 @@ trait CollectionRules {
 
   def sequence[S[_] : Indexable : Traverse, A, B](rule: Rule[A, B]): Rule[S[A], S[B]] =
     pure { values =>
-      Indexable[S].zipWithIndex(values).map {
+      Indexable[S].zipWithIndex(values).traverse {
         case (value, index) =>
           rule(value) leftMap (_ map (_ prefix index))
-      }.sequenceU
+      }
     }
 
   def mapValue[A: PathPrefix, B](key: A): Rule[Map[A, B], B] =
@@ -262,10 +262,10 @@ trait CollectionRules {
 
   def mapValues[A: PathPrefix, B, C](rule: Rule[B, C]): Rule[Map[A, B], Map[A, C]] =
     pure { in: Map[A, B] =>
-      in.toList.map {
+      in.toList.traverse {
         case (key, value) =>
           rule.prefix(key).apply(value).map(key -> _)
-      }.sequenceU
+      }
     } map (_.toMap)
 }
 

--- a/checklist/src/main/scala/checklist/Sizeable.scala
+++ b/checklist/src/main/scala/checklist/Sizeable.scala
@@ -1,0 +1,25 @@
+package checklist
+
+trait Sizeable[A] {
+  def size(a: A): Long
+}
+
+object Sizeable extends SizeableInstances with SizeableSyntax {
+  def apply[A](implicit sizeable: Sizeable[A]): Sizeable[A] = sizeable
+
+  def instance[A](f: A => Long): Sizeable[A] =
+    new Sizeable[A] {
+      def size(a: A): Long = f(a)
+    }
+}
+
+trait SizeableInstances extends LowPriorityIndexableInstances {
+  implicit val sizeableString: Sizeable[String] = Sizeable.instance(_.size.toLong)
+}
+
+trait LowPrioritySizeableInstances {
+  import cats.Foldable
+  import cats.implicits._
+  implicit def sizeableFoldable[F[_]: Foldable, A]: Sizeable[F[A]] = Sizeable.instance(_.size)
+  implicit def sizeableSeq[A]: Sizeable[Seq[A]] = Sizeable.instance(_.size.toLong)
+}

--- a/checklist/src/main/scala/checklist/Sizeable.scala
+++ b/checklist/src/main/scala/checklist/Sizeable.scala
@@ -13,7 +13,7 @@ object Sizeable extends SizeableInstances with SizeableSyntax {
     }
 }
 
-trait SizeableInstances extends LowPriorityIndexableInstances {
+trait SizeableInstances extends LowPrioritySizeableInstances {
   implicit val sizeableString: Sizeable[String] = Sizeable.instance(_.size.toLong)
 }
 

--- a/checklist/src/main/scala/checklist/SizeableSyntax.scala
+++ b/checklist/src/main/scala/checklist/SizeableSyntax.scala
@@ -1,0 +1,10 @@
+package checklist
+
+object SizeableSyntax extends SizeableSyntax
+
+trait SizeableSyntax {
+  implicit class SizeableOps[A](a: A)(implicit sizeable: Sizeable[A]) {
+    def size: Long = sizeable.size(a)
+  }
+}
+

--- a/checklist/src/main/scala/checklist/syntax.scala
+++ b/checklist/src/main/scala/checklist/syntax.scala
@@ -1,3 +1,3 @@
 package checklist
 
-object syntax extends Rule1Syntax with MessageSyntax with CheckedSyntax
+object syntax extends Rule1Syntax with MessageSyntax with CheckedSyntax with IndexableSyntax

--- a/checklist/src/main/scala/checklist/syntax.scala
+++ b/checklist/src/main/scala/checklist/syntax.scala
@@ -1,3 +1,3 @@
 package checklist
 
-object syntax extends Rule1Syntax with MessageSyntax with CheckedSyntax with IndexableSyntax
+object syntax extends Rule1Syntax with MessageSyntax with CheckedSyntax with IndexableSyntax with SizeableSyntax

--- a/checklist/src/test/scala/checklist/IndexableSpec.scala
+++ b/checklist/src/test/scala/checklist/IndexableSpec.scala
@@ -29,4 +29,13 @@ class IndexableSpec extends FreeSpec with Matchers {
     indexable.zipWithIndex(vector) should be(vector.zipWithIndex)
     indexable.mapWithIndex(vector)((a, b) => (a, b)) should be(indexable.zipWithIndex(vector))
   }
+
+  "Syntax" in {
+    import cats.data.NonEmptyList
+    val list = NonEmptyList.of('f', 'o', 'o')
+
+    list.zipWithIndex should be(Indexable[NonEmptyList].zipWithIndex(list))
+    list.mapWithIndex((a, i) => (a, i)) should be(Indexable[NonEmptyList].mapWithIndex(list)((a, i) => (a, i)))
+    list.traverseWithIndex((a, i) => Option((a, i))) should be(list.zipWithIndex.map { case (a, i) => Option((a, i))}.sequence)
+  }
 }

--- a/checklist/src/test/scala/checklist/IndexableSpec.scala
+++ b/checklist/src/test/scala/checklist/IndexableSpec.scala
@@ -1,0 +1,32 @@
+package checklist
+
+import org.scalatest._
+import cats.implicits._
+import Indexable._
+
+class IndexableSpec extends FreeSpec with Matchers {
+  "List Indexable" in {
+    val list = "foo".toList
+    listIndexable.zipWithIndex(list) should be(list.zipWithIndex)
+    listIndexable.mapWithIndex(list)((a, b) => (a, b)) should be(listIndexable.zipWithIndex(list))
+  }
+
+  "Vector Indexable" in {
+    val vector = "foo".toVector
+    vectorIndexable.zipWithIndex(vector) should be(vector.zipWithIndex)
+    vectorIndexable.mapWithIndex(vector)((a, b) => (a, b)) should be(vectorIndexable.zipWithIndex(vector))
+  }
+
+  "Stream Indexable" in {
+    val stream = "foo".toStream
+    streamIndexable.zipWithIndex(stream).take(3).toList should be(stream.zipWithIndex.take(3).toList)
+    streamIndexable.mapWithIndex(stream)((a, b) => (a, b)).take(3).toList should be(streamIndexable.zipWithIndex(stream).take(3).toList)
+  }
+
+  "Traverse Indexable" in {
+    val indexable = indexableFromTraverse[Vector]
+    val vector = "foo".toVector
+    indexable.zipWithIndex(vector) should be(vector.zipWithIndex)
+    indexable.mapWithIndex(vector)((a, b) => (a, b)) should be(indexable.zipWithIndex(vector))
+  }
+}

--- a/checklist/src/test/scala/checklist/ReadmeSpec.scala
+++ b/checklist/src/test/scala/checklist/ReadmeSpec.scala
@@ -1,8 +1,8 @@
 package checklist
 
 import cats.data.Ior
-import cats.instances.list._
 import org.scalatest._
+import cats.implicits._
 
 class ReadmeSpec extends FreeSpec with Matchers {
   import Rule._

--- a/checklist/src/test/scala/checklist/RuleSpec.scala
+++ b/checklist/src/test/scala/checklist/RuleSpec.scala
@@ -2,6 +2,7 @@ package checklist
 
 import cats.data.Ior
 import cats.implicits._
+import Sizeable._
 import org.scalatest._
 import monocle.macros.Lenses
 import Rule._
@@ -69,112 +70,225 @@ class ConverterRulesSpec extends FreeSpec with Matchers {
 }
 
 class PropertyRulesSpec extends FreeSpec with Matchers {
-  "eql" in {
-    val rule = eql(0)
-    rule(0)  should be(Ior.right(0))
-    rule(+1) should be(Ior.both(errors("Must be 0"), +1))
-    rule(-1) should be(Ior.both(errors("Must be 0"), -1))
+
+  "non-strict" - {
+    "eql" in {
+      val rule = eql(0)
+      rule(0)  should be(Ior.right(0))
+      rule(+1) should be(Ior.both(errors("Must be 0"), +1))
+      rule(-1) should be(Ior.both(errors("Must be 0"), -1))
+    }
+
+    "neq" in {
+      val rule = neq(0)
+      rule(0)  should be(Ior.both(errors("Must not be 0"), 0))
+      rule(+1) should be(Ior.right(+1))
+      rule(-1) should be(Ior.right(-1))
+    }
+
+    "lt" in {
+      val rule = lt(0)
+      rule(0)  should be(Ior.both(errors("Must be less than 0"), 0))
+      rule(1)  should be(Ior.both(errors("Must be less than 0"), 1))
+      rule(-1) should be(Ior.right(-1))
+    }
+
+    "lte" in {
+      val rule = lte(0)
+      rule(0)  should be(Ior.right(0))
+      rule(1)  should be(Ior.both(errors("Must be less than or equal to 0"), 1))
+      rule(-1) should be(Ior.right(-1))
+    }
+
+    "gt" in {
+      val rule = gt(0)
+      rule(0)  should be(Ior.both(errors("Must be greater than 0"), 0))
+      rule(1)  should be(Ior.right(1))
+      rule(-1) should be(Ior.both(errors("Must be greater than 0"), -1))
+    }
+
+    "gte" in {
+      val rule = gte(0)
+      rule(0)  should be(Ior.right(0))
+      rule(1)  should be(Ior.right(1))
+      rule(-1) should be(Ior.both(errors("Must be greater than or equal to 0"), -1))
+    }
+
+    "nonEmpty" in {
+      val rule = nonEmpty[String]
+      rule("")    should be(Ior.both(errors("Must not be empty"), ""))
+      rule(" ")   should be(Ior.right(" "))
+      rule(" a ") should be(Ior.right(" a "))
+    }
+
+    "lengthLt"  in {
+      val rule = lengthLt(5, errors("fail"))
+
+      rule("")      should be(Ior.right(""))
+      rule("abcd")  should be(Ior.right("abcd"))
+      rule("abcde") should be(Ior.both(errors("fail"), "abcde"))
+    }
+
+    "lengthLte" in {
+      val rule = lengthLte[String](5, errors("fail"))
+
+      rule("")       should be(Ior.right(""))
+      rule("abcde")  should be(Ior.right("abcde"))
+      rule("abcdef") should be(Ior.both(errors("fail"), "abcdef"))
+    }
+
+    "lengthGt" in {
+      val rule = lengthGt[String](1, errors("fail"))
+
+      rule("")   should be(Ior.both(errors("fail"), ""))
+      rule("a")  should be(Ior.both(errors("fail"), "a"))
+      rule("ab") should be(Ior.right("ab"))
+    }
+
+    "lengthGte" in {
+      val rule = lengthGte[String](2, errors("fail"))
+
+      rule("")   should be(Ior.both(errors("fail"), ""))
+      rule(" ")  should be(Ior.both(errors("fail"), " "))
+      rule("a")  should be(Ior.both(errors("fail"), "a"))
+      rule("ab") should be(Ior.right("ab"))
+    }
+
+    "matchesRegex" in {
+      val rule = matchesRegex("^[^@]+@[^@]+$".r)
+      rule("dave@example.com")  should be(Ior.right("dave@example.com"))
+      rule("dave@")             should be(Ior.both(errors("Must match the pattern '^[^@]+@[^@]+$'"), "dave@"))
+      rule("@example.com")      should be(Ior.both(errors("Must match the pattern '^[^@]+@[^@]+$'"), "@example.com"))
+      rule("dave@@example.com") should be(Ior.both(errors("Must match the pattern '^[^@]+@[^@]+$'"), "dave@@example.com"))
+    }
+
+    "notContainedIn" in {
+      val rule = notContainedIn(List(1, 2, 3))
+      rule(0) should be(Ior.right(0))
+      rule(1) should be(Ior.both(errors("Must not be one of the values 1, 2, 3"), 1))
+      rule(2) should be(Ior.both(errors("Must not be one of the values 1, 2, 3"), 2))
+      rule(3) should be(Ior.both(errors("Must not be one of the values 1, 2, 3"), 3))
+      rule(4) should be(Ior.right(4))
+    }
+
+    "containedIn" in {
+      val rule = containedIn(List(1, 2, 3))
+      rule(0) should be(Ior.both(errors("Must be one of the values 1, 2, 3"), 0))
+      rule(1) should be(Ior.right(1))
+      rule(2) should be(Ior.right(2))
+      rule(3) should be(Ior.right(3))
+      rule(4) should be(Ior.both(errors("Must be one of the values 1, 2, 3"), 4))
+    }
   }
 
-  "neq" in {
-    val rule = neq(0)
-    rule(0)  should be(Ior.both(errors("Must not be 0"), 0))
-    rule(+1) should be(Ior.right(+1))
-    rule(-1) should be(Ior.right(-1))
-  }
+  "strict" - {
+    "eqlStrict" in {
+      val rule = eqlStrict(0)
+      rule(0)  should be(Ior.right(0))
+      rule(+1) should be(Ior.left(errors("Must be 0")))
+      rule(-1) should be(Ior.left(errors("Must be 0")))
+    }
 
-  "lt" in {
-    val rule = lt(0)
-    rule(0)  should be(Ior.both(errors("Must be less than 0"), 0))
-    rule(1)  should be(Ior.both(errors("Must be less than 0"), 1))
-    rule(-1) should be(Ior.right(-1))
-  }
+    "neqStrict" in {
+      val rule = neqStrict(0)
+      rule(0)  should be(Ior.left(errors("Must not be 0")))
+      rule(+1) should be(Ior.right(+1))
+      rule(-1) should be(Ior.right(-1))
+    }
 
-  "lte" in {
-    val rule = lte(0)
-    rule(0)  should be(Ior.right(0))
-    rule(1)  should be(Ior.both(errors("Must be less than or equal to 0"), 1))
-    rule(-1) should be(Ior.right(-1))
-  }
+    "ltStrict" in {
+      val rule = ltStrict(0)
+      rule(0)  should be(Ior.left(errors("Must be less than 0")))
+      rule(1)  should be(Ior.left(errors("Must be less than 0")))
+      rule(-1) should be(Ior.right(-1))
+    }
 
-  "gt" in {
-    val rule = gt(0)
-    rule(0)  should be(Ior.both(errors("Must be greater than 0"), 0))
-    rule(1)  should be(Ior.right(1))
-    rule(-1) should be(Ior.both(errors("Must be greater than 0"), -1))
-  }
+    "lteStrict" in {
+      val rule = lteStrict(0)
+      rule(0)  should be(Ior.right(0))
+      rule(1)  should be(Ior.left(errors("Must be less than or equal to 0")))
+      rule(-1) should be(Ior.right(-1))
+    }
 
-  "gte" in {
-    val rule = gte(0)
-    rule(0)  should be(Ior.right(0))
-    rule(1)  should be(Ior.right(1))
-    rule(-1) should be(Ior.both(errors("Must be greater than or equal to 0"), -1))
-  }
+    "gtStrict" in {
+      val rule = gtStrict(0)
+      rule(0)  should be(Ior.left(errors("Must be greater than 0")))
+      rule(1)  should be(Ior.right(1))
+      rule(-1) should be(Ior.left(errors("Must be greater than 0")))
+    }
 
-  "nonEmpty" in {
-    val rule = nonEmpty[String]
-    rule("")    should be(Ior.both(errors("Must not be empty"), ""))
-    rule(" ")   should be(Ior.right(" "))
-    rule(" a ") should be(Ior.right(" a "))
-  }
+    "gteStrict" in {
+      val rule = gteStrict(0)
+      rule(0)  should be(Ior.right(0))
+      rule(1)  should be(Ior.right(1))
+      rule(-1) should be(Ior.left(errors("Must be greater than or equal to 0")))
+    }
 
-  "lengthLt"  in {
-    val rule = lengthLt(5, errors("fail"))
+    "nonEmptyStrict" in {
+      val rule = nonEmptyStrict[String]
+      rule("")    should be(Ior.left(errors("Must not be empty")))
+      rule(" ")   should be(Ior.right(" "))
+      rule(" a ") should be(Ior.right(" a "))
+    }
 
-    rule("")      should be(Ior.right(""))
-    rule("abcd")  should be(Ior.right("abcd"))
-    rule("abcde") should be(Ior.both(errors("fail"), "abcde"))
-  }
+    "lengthLt"  in {
+      val rule = lengthLtStrict(5, errors("fail"))
 
-  "lengthLte" in {
-    val rule = lengthLte[String](5, errors("fail"))
+      rule("")      should be(Ior.right(""))
+      rule("abcd")  should be(Ior.right("abcd"))
+      rule("abcde") should be(Ior.left(errors("fail")))
+    }
 
-    rule("")       should be(Ior.right(""))
-    rule("abcde")  should be(Ior.right("abcde"))
-    rule("abcdef") should be(Ior.both(errors("fail"), "abcdef"))
-  }
+    "lengthLteStrict" in {
+      val rule = lengthLteStrict[String](5, errors("fail"))
 
-  "lengthGt" in {
-    val rule = lengthGt[String](1, errors("fail"))
+      rule("")       should be(Ior.right(""))
+      rule("abcde")  should be(Ior.right("abcde"))
+      rule("abcdef") should be(Ior.left(errors("fail")))
+    }
 
-    rule("")   should be(Ior.both(errors("fail"), ""))
-    rule("a")  should be(Ior.both(errors("fail"), "a"))
-    rule("ab") should be(Ior.right("ab"))
-  }
+    "lengthGtStrict" in {
+      val rule = lengthGtStrict[String](1, errors("fail"))
 
-  "lengthGte" in {
-    val rule = lengthGte[String](2, errors("fail"))
+      rule("")   should be(Ior.left(errors("fail")))
+      rule("a")  should be(Ior.left(errors("fail")))
+      rule("ab") should be(Ior.right("ab"))
+    }
 
-    rule("")   should be(Ior.both(errors("fail"), ""))
-    rule(" ")  should be(Ior.both(errors("fail"), " "))
-    rule("a")  should be(Ior.both(errors("fail"), "a"))
-    rule("ab") should be(Ior.right("ab"))
-  }
+    "lengthGteStrict" in {
+      val rule = lengthGteStrict[String](2, errors("fail"))
 
-  "matchesRegex" in {
-    val rule = matchesRegex("^[^@]+@[^@]+$".r)
-    rule("dave@example.com")  should be(Ior.right("dave@example.com"))
-    rule("dave@")             should be(Ior.both(errors("Must match the pattern '^[^@]+@[^@]+$'"), "dave@"))
-    rule("@example.com")      should be(Ior.both(errors("Must match the pattern '^[^@]+@[^@]+$'"), "@example.com"))
-    rule("dave@@example.com") should be(Ior.both(errors("Must match the pattern '^[^@]+@[^@]+$'"), "dave@@example.com"))
-  }
+      rule("")   should be(Ior.left(errors("fail")))
+      rule(" ")  should be(Ior.left(errors("fail")))
+      rule("a")  should be(Ior.left(errors("fail")))
+      rule("ab") should be(Ior.right("ab"))
+    }
 
-  "notContainedIn" in {
-    val rule = notContainedIn(List(1, 2, 3))
-    rule(0) should be(Ior.right(0))
-    rule(1) should be(Ior.both(errors("Must not be one of the values 1, 2, 3"), 1))
-    rule(2) should be(Ior.both(errors("Must not be one of the values 1, 2, 3"), 2))
-    rule(3) should be(Ior.both(errors("Must not be one of the values 1, 2, 3"), 3))
-    rule(4) should be(Ior.right(4))
-  }
+    "matchesRegexStrict" in {
+      val rule = matchesRegexStrict("^[^@]+@[^@]+$".r)
+      rule("dave@example.com")  should be(Ior.right("dave@example.com"))
+      rule("dave@")             should be(Ior.left(errors("Must match the pattern '^[^@]+@[^@]+$'")))
+      rule("@example.com")      should be(Ior.left(errors("Must match the pattern '^[^@]+@[^@]+$'")))
+      rule("dave@@example.com") should be(Ior.left(errors("Must match the pattern '^[^@]+@[^@]+$'")))
+    }
 
-  "containedIn" in {
-    val rule = containedIn(List(1, 2, 3))
-    rule(0) should be(Ior.both(errors("Must be one of the values 1, 2, 3"), 0))
-    rule(1) should be(Ior.right(1))
-    rule(2) should be(Ior.right(2))
-    rule(3) should be(Ior.right(3))
-    rule(4) should be(Ior.both(errors("Must be one of the values 1, 2, 3"), 4))
+    "notContainedInStrict" in {
+      val rule = notContainedInStrict(List(1, 2, 3))
+      rule(0) should be(Ior.right(0))
+      rule(1) should be(Ior.left(errors("Must not be one of the values 1, 2, 3")))
+      rule(2) should be(Ior.left(errors("Must not be one of the values 1, 2, 3")))
+      rule(3) should be(Ior.left(errors("Must not be one of the values 1, 2, 3")))
+      rule(4) should be(Ior.right(4))
+    }
+
+    "containedInStrict" in {
+      val rule = containedInStrict(List(1, 2, 3))
+      rule(0) should be(Ior.left(errors("Must be one of the values 1, 2, 3")))
+      rule(1) should be(Ior.right(1))
+      rule(2) should be(Ior.right(2))
+      rule(3) should be(Ior.right(3))
+      rule(4) should be(Ior.left(errors("Must be one of the values 1, 2, 3")))
+    }
   }
 }
 

--- a/checklist/src/test/scala/checklist/RuleSpec.scala
+++ b/checklist/src/test/scala/checklist/RuleSpec.scala
@@ -1,6 +1,7 @@
 package checklist
 
 import cats.data.Ior
+import cats.implicits._
 import org.scalatest._
 import monocle.macros.Lenses
 import Rule._
@@ -118,7 +119,7 @@ class PropertyRulesSpec extends FreeSpec with Matchers {
   }
 
   "lengthLt"  in {
-    val rule = lengthLt[String](5, errors("fail"))
+    val rule = lengthLt(5, errors("fail"))
 
     rule("")      should be(Ior.right(""))
     rule("abcd")  should be(Ior.right("abcd"))

--- a/checklist/src/test/scala/checklist/SizeableSpec.scala
+++ b/checklist/src/test/scala/checklist/SizeableSpec.scala
@@ -1,0 +1,20 @@
+package checklist
+
+import org.scalatest._
+import cats.implicits._
+
+class SizeableSpec extends FreeSpec with Matchers {
+  "Sizeable Foldable" in {
+    def vectorSizeable[A] = Sizeable.sizeableFoldable[Vector, A]
+    vectorSizeable.size(Vector(1,2,3,4)) should be(4)
+  }
+
+  "Sizeable Seq" in {
+    def seqSizable[A] = Sizeable.sizeableSeq[A]
+    seqSizable.size(Seq(1,2,3,4)) should be(4)
+  }
+
+  "Sizeable String" in {
+    Sizeable.sizeableString.size("foo") should be(3)
+  }
+}


### PR DESCRIPTION
In this PR, I've created strict variants of all the base property rules, and I've removed the Seq view restrictions that were on some of them... Instead, they now depend on either `Foldable`, `Sizeable`, `Monoid`, or `Indexable`. 

* `Sizeable` is just a typeclass for things which have size.
* `Indexable` was updated to be based on `mapWithIndex` rather than `zipWithIndex`. This lets us generalize `Indexable`, such that forall `F[_]: Foldable`, `F` is also `Indexable`. Additionally, `Indexable` will be able to be removed once we move to cats 1.0.0, since these things are built in to `Traverse` there.
* `Monoid` is used for the non-empty rule, rather than the seq view that was there before.  This means users can define their own things which may be empty.

Some consequences of this, are that `Seq` won't work for anything which depends on Foldable. Depending on cats' alleycats package should get you unlawful typeclasses for those, however.