### PR TITLE
Add law tests and profunctor instance for Rule.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,9 +35,10 @@ lazy val checklist = crossProject.
     libraryDependencies ++= Seq(
       "org.scala-lang"               % "scala-reflect"  % scalaVersion.value % Provided,
       "org.typelevel"              %%% "cats-core"      % "0.9.0",
+      "org.typelevel"              %%% "cats-laws"      % "0.9.0" % Test,
       "com.github.julien-truffaut" %%% "monocle-core"   % "1.4.0",
       "com.github.julien-truffaut" %%% "monocle-macro"  % "1.4.0",
-      "org.scalatest"              %%% "scalatest"      % "3.0.0" % Test
+      "org.scalatest"              %%% "scalatest"      % "3.0.3" % Test
     )
   )
 

--- a/checklist/src/main/scala/checklist/Message.scala
+++ b/checklist/src/main/scala/checklist/Message.scala
@@ -1,5 +1,6 @@
 package checklist
 
+import cats.{Eq, Order}
 import cats.data.NonEmptyList
 
 sealed abstract class Message(val isError: Boolean, val isWarning: Boolean) {
@@ -16,7 +17,7 @@ final case class ErrorMessage(text: String, path: Path = PNil) extends Message(t
 
 final case class WarningMessage(text: String, path: Path = PNil) extends Message(false, true)
 
-object Message extends MessageConstructors
+object Message extends MessageConstructors with MessageInstances
 
 trait MessageConstructors {
   def errors[A](head: A, tail: A *)(implicit promoter: ToMessage[A]): NonEmptyList[Message] =
@@ -24,4 +25,12 @@ trait MessageConstructors {
 
   def warnings[A](head: A, tail: A *)(implicit promoter: ToMessage[A]): NonEmptyList[Message] =
     NonEmptyList.of(head, tail : _*).map(promoter.toWarning)
+}
+
+trait MessageInstances {
+
+  implicit def orderChecklistMessage: Order[Message] = Order.by[Message, Path](_.path)
+
+  implicit def eqChecklistMessage: Eq[Message] =
+    Eq.fromUniversalEquals[Message]
 }

--- a/checklist/src/main/scala/checklist/Path.scala
+++ b/checklist/src/main/scala/checklist/Path.scala
@@ -1,5 +1,7 @@
 package checklist
 
+import cats.Order
+
 sealed abstract class Path {
   def pathString: String = this match {
     case PNil               => ""
@@ -23,6 +25,8 @@ sealed abstract class Path {
 
   override def toString = s"Path($pathString)"
 }
+
+object Path extends PathInstances
 
 case object PNil extends Path
 final case class PField(head: String, tail: Path = PNil) extends Path
@@ -60,4 +64,9 @@ object PathPrefix {
 
   implicit def prefixToPath[A](value: A)(implicit prefixer: PathPrefix[A]): Path =
     prefixer.path(value)
+}
+
+trait PathInstances {
+  import cats.instances.string._
+  implicit val pathOrder: Order[Path] = Order.by[Path, String](_.pathString)
 }

--- a/checklist/src/main/scala/checklist/Rule.scala
+++ b/checklist/src/main/scala/checklist/Rule.scala
@@ -1,13 +1,15 @@
 package checklist
 
-import cats.{Applicative, Traverse, Monoid}
+import cats.{Applicative, Monoid, Traverse}
 import cats.data.{Ior, Kleisli}
 import cats.implicits._
 import monocle.PLens
+
 import scala.language.higherKinds
 import scala.util.matching.Regex
 import Message.errors
 import cats.data.NonEmptyList
+import cats.functor.Profunctor
 import checklist.IndexableSyntax._
 import checklist.SizeableSyntax._
 
@@ -409,5 +411,11 @@ trait RuleInstances {
 
       override def product[B, C](rule1: Rule[A, B], rule2: Rule[A, C]): Rule[A, (B, C)] =
         rule1 zip rule2
+    }
+
+  implicit val ruleProfunctor: Profunctor[Rule] =
+    new Profunctor[Rule] {
+      override def dimap[A, B, C, D](fab: Rule[A, B])(f: (C) => A)(g: (B) => D) =
+        fab.contramap(f).map(g)
     }
 }

--- a/checklist/src/test/scala/checklist/laws/RuleLawTests.scala
+++ b/checklist/src/test/scala/checklist/laws/RuleLawTests.scala
@@ -1,0 +1,32 @@
+package checklist.laws
+
+import cats.Eq
+import cats.data.{Ior, NonEmptyList}
+import cats.laws.discipline.{ApplicativeTests, ProfunctorTests}
+import cats.laws.discipline.arbitrary._
+import cats.laws.discipline.eq._
+import checklist._
+import org.scalacheck.Arbitrary
+import org.scalatest.FunSuite
+import org.typelevel.discipline.scalatest.Discipline
+import cats.implicits._
+
+class RuleLawTests extends FunSuite with Discipline {
+
+  implicit def arbRule[A: Arbitrary, B: Arbitrary](implicit arbF: Arbitrary[A => Ior[A, B]]): Arbitrary[Rule[A, B]] = Arbitrary(
+    for {
+      f <- arbF.arbitrary
+    } yield Rule.pure(f.map {
+      case Ior.Both(_, b) => Ior.both(NonEmptyList.of(ErrorMessage("both")), b)
+      case Ior.Left(_) => Ior.left(NonEmptyList.of(ErrorMessage("left")))
+      case Ior.Right(a) => Ior.right(a)
+    })
+  )
+
+  implicit def ruleEq[A: Arbitrary, B: Eq]: Eq[Rule[A, B]] =
+    catsLawsEqForFn1[A, Checked[B]].contramap[Rule[A, B]](rule => rule.apply _)
+
+
+  checkAll("Rule[Int, String]", ApplicativeTests[Rule[Int, ?]].applicative[String, String, String])
+  checkAll("Rule[Int, String]", ProfunctorTests[Rule].profunctor[Int, Int, Int, String, String, String])
+}


### PR DESCRIPTION
Additionally, made Eq and Order instances for Message and Path.  Those will need law tests as well, but cats 0.9.0 doesn't have laws for those.